### PR TITLE
fix: ignore parameter decorators indent

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -196,7 +196,7 @@ test('export', (t): void => {
         ImportDeclaration: 1,
         flatTernaryExpressions: false,
         ignoreComments: false,
-        ignoredNodes: ['TemplateLiteral *', 'JSXElement', 'JSXElement > *', 'JSXAttribute', 'JSXIdentifier', 'JSXNamespacedName', 'JSXMemberExpression', 'JSXSpreadAttribute', 'JSXExpressionContainer', 'JSXOpeningElement', 'JSXClosingElement', 'JSXFragment', 'JSXOpeningFragment', 'JSXClosingFragment', 'JSXText', 'JSXEmptyExpression', 'JSXSpreadChild'],
+        ignoredNodes: ['TemplateLiteral *', 'JSXElement', 'JSXElement > *', 'JSXAttribute', 'JSXIdentifier', 'JSXNamespacedName', 'JSXMemberExpression', 'JSXSpreadAttribute', 'JSXExpressionContainer', 'JSXOpeningElement', 'JSXClosingElement', 'JSXFragment', 'JSXOpeningFragment', 'JSXClosingFragment', 'JSXText', 'JSXEmptyExpression', 'JSXSpreadChild', 'FunctionExpression > .params[decorators.length > 0]', 'FunctionExpression > .params > :matches(Decorator, :not(:first-child))', 'ClassBody.body > PropertyDefinition[decorators.length > 0] > .key'],
         offsetTernaryExpressions: true
       }],
       '@typescript-eslint/key-spacing': ['error', { beforeColon: false, afterColon: true }],

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,6 +43,15 @@ function fromEntries<T> (iterable: Array<[string, T]>): Record<string, T> {
   }, {})
 }
 
+const disabledRules = fromEntries(equivalents.map((name) => [name, 'off']))
+const enabledRules = fromEntries(equivalents.map((name) => [`@typescript-eslint/${name}`, ruleFromStandard(name)]));
+// Ignore parameter decorators indent. See: https://github.com/typescript-eslint/typescript-eslint/issues/1824#issuecomment-957559729
+(enabledRules['@typescript-eslint/indent'] as Linter.RuleLevelAndOptions)[2].ignoredNodes.push(
+  'FunctionExpression > .params[decorators.length > 0]',
+  'FunctionExpression > .params > :matches(Decorator, :not(:first-child))',
+  'ClassBody.body > PropertyDefinition[decorators.length > 0] > .key'
+)
+
 const config: Linter.Config = {
   extends: 'eslint-config-standard',
   plugins: ['@typescript-eslint'],
@@ -54,12 +63,12 @@ const config: Linter.Config = {
     'no-undef': 'off',
 
     // Rules replaced by @typescript-eslint versions:
-    ...fromEntries(equivalents.map((name) => [name, 'off'])),
+    ...disabledRules,
     camelcase: 'off',
     'no-use-before-define': 'off',
 
     // @typescript-eslint versions of Standard.js rules:
-    ...fromEntries(equivalents.map((name) => [`@typescript-eslint/${name}`, ruleFromStandard(name)])),
+    ...enabledRules,
     '@typescript-eslint/no-use-before-define': ['error', {
       functions: false,
       classes: false,


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[x] Documentation update
[x] Bug fix
[ ] New feature
[ ] Other, please explain:

**What changes did you make? (Give an overview)**

In Nestjs project (or any other project using decorator), using this eslint-config will make wrong indent in parameter decorator and property decorator.

```ts
import { Body, Headers, Query, Inject, Get, Post } from '@nestjs/common'

export class Foo {
  @Inject()
  a: any

  @Inject()
  b: any

  constructor(
    @Headers()
    @Query()
    q: any,
    @Headers()
    h: any,
    @Body()
    b: any
  ) {
    console.log(q)
    console.log(h)
    console.log(b)
  }

  get(
    @Query() q: any,
    @Headers() h: any
  ) {
    console.log(q)
    console.log(h)
  }
}

```

Code above will finally format to code below, whose parameter and property indents are wrong.

```ts
import { Body, Headers, Query, Inject } from '@nestjs/common'

export class Foo {
  @Inject()
    a: any

  @Inject()
    b: any

  constructor(
  @Headers()
  @Query()
    q: any,
    @Headers()
    h: any,
    @Body()
    b: any
  ) {
    console.log(q)
    console.log(h)
    console.log(b)
  }

  get(
  @Query() q: any,
    @Headers() h: any
  ) {
    console.log(q)
    console.log(h)
  }
}
```

**Which issue (if any) does this pull request address?**

This is a bug belongs to `@typescript-eslint`. However, it's impossible to fix it. 
https://github.com/typescript-eslint/typescript-eslint/issues/1824

The solution is https://github.com/typescript-eslint/typescript-eslint/issues/1824#issuecomment-957559729

**Is there anything you'd like reviewers to focus on?**
