### PR TITLE
Make use of typescript import resolver

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "52.0.0",
       "license": "MIT",
       "dependencies": {
+        "eslint-import-resolver-typescript": "^3.6.1",
         "eslint-plugin-import": "^2.25.2",
         "eslint-plugin-n": "^17.0.0",
         "eslint-plugin-promise": "^6.0.0",
@@ -4386,6 +4387,30 @@
       "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
       "dependencies": {
         "ms": "^2.1.1"
+      }
+    },
+    "node_modules/eslint-import-resolver-typescript": {
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-typescript/-/eslint-import-resolver-typescript-3.6.1.tgz",
+      "integrity": "sha512-xgdptdoi5W3niYeuQxKmzVDTATvLYqhpwmykwsh7f6HIOStGWEIL9iqZgQDF9u9OEzrRwR8no5q2VT+bjAujTg==",
+      "dependencies": {
+        "debug": "^4.3.4",
+        "enhanced-resolve": "^5.12.0",
+        "eslint-module-utils": "^2.7.4",
+        "fast-glob": "^3.3.1",
+        "get-tsconfig": "^4.5.0",
+        "is-core-module": "^2.11.0",
+        "is-glob": "^4.0.3"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/unts/projects/eslint-import-resolver-ts"
+      },
+      "peerDependencies": {
+        "eslint": "*",
+        "eslint-plugin-import": "*"
       }
     },
     "node_modules/eslint-module-utils": {

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "TypeScript"
   ],
   "dependencies": {
+    "eslint-import-resolver-typescript": "^3.6.1",
     "eslint-plugin-import": "^2.25.2",
     "eslint-plugin-n": "^17.0.0",
     "eslint-plugin-promise": "^6.0.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -278,6 +278,7 @@ const rules = {
   'import/no-duplicates': ['error'],
   'import/no-named-default': ['error'],
   'import/no-webpack-loader-syntax': ['error'],
+  'import/no-unresolved': ['error'],
 
   'n/handle-callback-err': ['error', '^(err|error)$'],
   'n/no-callback-literal': ['error'],
@@ -299,6 +300,12 @@ const config: TSESLint.FlatConfig.Config = {
     parser,
     parserOptions: {
       project: true
+    }
+  },
+  settings: {
+    'import/resolver': {
+      typescript: true,
+      node: true
     }
   },
   plugins: {

--- a/src/test/_util.ts
+++ b/src/test/_util.ts
@@ -60,6 +60,12 @@ export const expectedExportedValue: TSESLint.FlatConfig.Config = {
       project: true
     }
   },
+  settings: {
+    'import/resolver': {
+      typescript: true,
+      node: true
+    }
+  },
   plugins: {
     '@typescript-eslint': tseslintPlugin,
     import: importPlugin,
@@ -180,6 +186,7 @@ export const expectedExportedValue: TSESLint.FlatConfig.Config = {
     'import/no-duplicates': ['error'],
     'import/no-named-default': ['error'],
     'import/no-webpack-loader-syntax': ['error'],
+    'import/no-unresolved': ['error'],
 
     'n/handle-callback-err': ['error', '^(err|error)$'],
     'n/no-callback-literal': ['error'],

--- a/src/test/rules-to-consider.ts
+++ b/src/test/rules-to-consider.ts
@@ -161,7 +161,6 @@ const notYetConsideredRules = [
   'import/no-restricted-paths',
   'import/no-self-import',
   'import/no-unassigned-import',
-  'import/no-unresolved',
   'import/no-unused-modules',
   'import/no-useless-path-segments',
   'import/order',


### PR DESCRIPTION
This pull request includes [eslint-import-resolver-typescript](https://github.com/import-js/eslint-import-resolver-typescript) as a peer dependency and enables TypeScript resolution for `eslint-plugin-import`. And sets  `import/no-unresolved` to `error`

Doing so we will also avoid having extraneous looking dependency in consumers package.json:
```js
...
    "eslint-config-love": "46.0.0",
    "eslint-import-resolver-typescript": "3.6.1",
...
```