### PR TITLE
feat!: @typescript-eslint/no-empty-object-type

### DIFF
--- a/src/_intentionally-unused-rules.ts
+++ b/src/_intentionally-unused-rules.ts
@@ -25,4 +25,7 @@ export const intentionallyUnusedRules: string[] = [
 
   // Covered by strict TypeScript
   '@typescript-eslint/no-invalid-this',
+
+  // Covered by `@typescript-eslint/no-empty-object-type`
+  '@typescript-eslint/no-empty-interface',
 ]

--- a/src/index.ts
+++ b/src/index.ts
@@ -159,10 +159,6 @@ const rules = {
       allow: [],
     },
   ],
-  '@typescript-eslint/no-empty-interface': [
-    'error',
-    { allowSingleExtends: true },
-  ],
   '@typescript-eslint/no-explicit-any': [
     'error',
     { fixToUnknown: false, ignoreRestArgs: false },
@@ -171,6 +167,10 @@ const rules = {
   '@typescript-eslint/no-extraneous-class': [
     'error',
     { allowWithDecorator: true },
+  ],
+  '@typescript-eslint/no-empty-object-type': [
+    'error',
+    { allowInterfaces: 'with-single-extends', allowObjectTypes: 'never' },
   ],
   '@typescript-eslint/no-floating-promises': ['error'],
   '@typescript-eslint/no-for-in-array': ['error'],

--- a/src/test/_expected-exported-value.ts
+++ b/src/test/_expected-exported-value.ts
@@ -319,10 +319,6 @@ export const expectedExportedValue: TSESLint.FlatConfig.Config = {
         allow: [],
       },
     ],
-    '@typescript-eslint/no-empty-interface': [
-      'error',
-      { allowSingleExtends: true },
-    ],
     '@typescript-eslint/no-explicit-any': [
       'error',
       { fixToUnknown: false, ignoreRestArgs: false },
@@ -331,6 +327,10 @@ export const expectedExportedValue: TSESLint.FlatConfig.Config = {
     '@typescript-eslint/no-extraneous-class': [
       'error',
       { allowWithDecorator: true },
+    ],
+    '@typescript-eslint/no-empty-object-type': [
+      'error',
+      { allowInterfaces: 'with-single-extends', allowObjectTypes: 'never' },
     ],
     '@typescript-eslint/no-floating-promises': ['error'],
     '@typescript-eslint/no-for-in-array': ['error'],

--- a/src/test/_rules_to_consider.ts
+++ b/src/test/_rules_to_consider.ts
@@ -1,5 +1,4 @@
 export const rulesToConsider = [
-  '@typescript-eslint/no-empty-object-type',
   '@typescript-eslint/no-inferrable-types',
   '@typescript-eslint/no-magic-numbers',
   '@typescript-eslint/no-meaningless-void-operator',


### PR DESCRIPTION
remove redundant `@typescript-eslint/no-empty-interface`

Co-authored-by: Rostislav Simonik <rostislav.simonik@technologystudio.sk>
