### PR TITLE
fix: rm empty object from @typescript-eslint/ban-types

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -60,13 +60,6 @@ const rules = {
             '- If you want a type meaning "any value", you probably want `unknown` instead.',
           ].join('\n'),
         },
-        '{}': {
-          message: [
-            '`{}` actually means "any non-nullish value".',
-            '- If you want a type meaning "any object", you probably want `Record<string, unknown>` instead.',
-            '- If you want a type meaning "any value", you probably want `unknown` instead.',
-          ].join('\n'),
-        },
       },
     },
   ],

--- a/src/test/_expected-exported-value.ts
+++ b/src/test/_expected-exported-value.ts
@@ -220,13 +220,6 @@ export const expectedExportedValue: TSESLint.FlatConfig.Config = {
               '- If you want a type meaning "any value", you probably want `unknown` instead.',
             ].join('\n'),
           },
-          '{}': {
-            message: [
-              '`{}` actually means "any non-nullish value".',
-              '- If you want a type meaning "any object", you probably want `Record<string, unknown>` instead.',
-              '- If you want a type meaning "any value", you probably want `unknown` instead.',
-            ].join('\n'),
-          },
         },
       },
     ],


### PR DESCRIPTION
Covered by @typescript-eslint/no-empty-object-type
