### PR TITLE
feat: @typescript-eslint/no-unsafe-type-assertion

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,12 +16,12 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/utils": "^8.12.0",
+        "@typescript-eslint/utils": "^8.15.0",
         "eslint-plugin-eslint-comments": "^3.2.0",
         "eslint-plugin-import": "^2.31.0",
         "eslint-plugin-n": "^17.0.0",
         "eslint-plugin-promise": "^7.0.0",
-        "typescript-eslint": "^8.12.0"
+        "typescript-eslint": "^8.15.0"
       },
       "devDependencies": {
         "@commitlint/cli": "19.6.0",
@@ -50,7 +50,7 @@
         "semver": "7.6.3",
         "type-fest": "4.27.0",
         "typescript": "5.6.3",
-        "typescript-eslint_bottom": "npm:typescript-eslint@8.12.0"
+        "typescript-eslint_bottom": "npm:typescript-eslint@8.15.0"
       },
       "peerDependencies": {
         "eslint": "^9.0.0",
@@ -12862,75 +12862,15 @@
     },
     "node_modules/typescript-eslint_bottom": {
       "name": "typescript-eslint",
-      "version": "8.12.0",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.12.0.tgz",
-      "integrity": "sha512-m8aQM4pqc17dcD3BsQzUqVXkcclCspuCCv7GhYlwMWNYAXFV8xJkn8vUM8YxoR78BY6S+NX/J7rfNVaGNLgXgQ==",
+      "version": "8.15.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.15.0.tgz",
+      "integrity": "sha512-wY4FRGl0ZI+ZU4Jo/yjdBu0lVTSML58pu6PgGtJmCufvzfV565pUF6iACQt092uFOd49iLOTX/sEVmHtbSrS+w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.12.0",
-        "@typescript-eslint/parser": "8.12.0",
-        "@typescript-eslint/utils": "8.12.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/typescript-eslint_bottom/node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.12.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.12.0.tgz",
-      "integrity": "sha512-uRqchEKT0/OwDePTwCjSFO2aH4zccdeQ7DgAzM/8fuXc+PAXvpdMRbuo+oCmK1lSfXssk2UUBNiWihobKxQp/g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@eslint-community/regexpp": "^4.10.0",
-        "@typescript-eslint/scope-manager": "8.12.0",
-        "@typescript-eslint/type-utils": "8.12.0",
-        "@typescript-eslint/utils": "8.12.0",
-        "@typescript-eslint/visitor-keys": "8.12.0",
-        "graphemer": "^1.4.0",
-        "ignore": "^5.3.1",
-        "natural-compare": "^1.4.0",
-        "ts-api-utils": "^1.3.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "@typescript-eslint/parser": "^8.0.0 || ^8.0.0-alpha.0",
-        "eslint": "^8.57.0 || ^9.0.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/typescript-eslint_bottom/node_modules/@typescript-eslint/parser": {
-      "version": "8.12.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.12.0.tgz",
-      "integrity": "sha512-7U20duDQWAOhCk2VtyY41Vor/CJjiEW063Zel9aoRXq89FQ/jr+0e0m3kxh9Sk5SFW9B1AblVIBtXd+1xQ1NWQ==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "@typescript-eslint/scope-manager": "8.12.0",
-        "@typescript-eslint/types": "8.12.0",
-        "@typescript-eslint/typescript-estree": "8.12.0",
-        "@typescript-eslint/visitor-keys": "8.12.0",
-        "debug": "^4.3.4"
+        "@typescript-eslint/eslint-plugin": "8.15.0",
+        "@typescript-eslint/parser": "8.15.0",
+        "@typescript-eslint/utils": "8.15.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -12946,133 +12886,6 @@
         "typescript": {
           "optional": true
         }
-      }
-    },
-    "node_modules/typescript-eslint_bottom/node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.12.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.12.0.tgz",
-      "integrity": "sha512-jbuCXK18iEshRFUtlCIMAmOKA6OAsKjo41UcXPqx7ZWh2b4cmg6pV/pNcZSB7oW9mtgF95yizr7Jnwt3IUD2pA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/types": "8.12.0",
-        "@typescript-eslint/visitor-keys": "8.12.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/typescript-eslint_bottom/node_modules/@typescript-eslint/type-utils": {
-      "version": "8.12.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.12.0.tgz",
-      "integrity": "sha512-cHioAZO/nLgyzTmwv7gWIjEKMHSbioKEZqLCaItTn7RvJP1QipuGVwEjPJa6Kv9u9UiUMVAESY9JH186TjKITw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/typescript-estree": "8.12.0",
-        "@typescript-eslint/utils": "8.12.0",
-        "debug": "^4.3.4",
-        "ts-api-utils": "^1.3.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/typescript-eslint_bottom/node_modules/@typescript-eslint/types": {
-      "version": "8.12.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.12.0.tgz",
-      "integrity": "sha512-Cc+iNtqBJ492f8KLEmKXe1l6683P0MlFO8Bk1NMphnzVIGH4/Wn9kvandFH+gYR1DDUjH/hgeWRGdO5Tj8gjYg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/typescript-eslint_bottom/node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.12.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.12.0.tgz",
-      "integrity": "sha512-a4koVV7HHVOQWcGb6ZcAlunJnAdwo/CITRbleQBSjq5+2WLoAJQCAAiecvrAdSM+n/man6Ghig5YgdGVIC6xqw==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "@typescript-eslint/types": "8.12.0",
-        "@typescript-eslint/visitor-keys": "8.12.0",
-        "debug": "^4.3.4",
-        "fast-glob": "^3.3.2",
-        "is-glob": "^4.0.3",
-        "minimatch": "^9.0.4",
-        "semver": "^7.6.0",
-        "ts-api-utils": "^1.3.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/typescript-eslint_bottom/node_modules/@typescript-eslint/utils": {
-      "version": "8.12.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.12.0.tgz",
-      "integrity": "sha512-5i1tqLwlf0fpX1j05paNKyIzla/a4Y3Xhh6AFzi0do/LDJLvohtZYaisaTB9kq0D4uBocAxWDTGzNMOCCwIgXA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@eslint-community/eslint-utils": "^4.4.0",
-        "@typescript-eslint/scope-manager": "8.12.0",
-        "@typescript-eslint/types": "8.12.0",
-        "@typescript-eslint/typescript-estree": "8.12.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0"
-      }
-    },
-    "node_modules/typescript-eslint_bottom/node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.12.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.12.0.tgz",
-      "integrity": "sha512-2rXkr+AtZZLuNY18aUjv5wtB9oUiwY1WnNi7VTsdCdy1m958ULeUKoAegldQTjqpbpNJ5cQ4egR8/bh5tbrKKQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/types": "8.12.0",
-        "eslint-visitor-keys": "^3.4.3"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
       }
     },
     "node_modules/uglify-js": {

--- a/package.json
+++ b/package.json
@@ -57,12 +57,12 @@
     "TypeScript"
   ],
   "dependencies": {
-    "@typescript-eslint/utils": "^8.12.0",
+    "@typescript-eslint/utils": "^8.15.0",
     "eslint-plugin-eslint-comments": "^3.2.0",
     "eslint-plugin-import": "^2.31.0",
     "eslint-plugin-n": "^17.0.0",
     "eslint-plugin-promise": "^7.0.0",
-    "typescript-eslint": "^8.12.0"
+    "typescript-eslint": "^8.15.0"
   },
   "peerDependencies": {
     "eslint": "^9.0.0",
@@ -95,6 +95,6 @@
     "semver": "7.6.3",
     "type-fest": "4.27.0",
     "typescript": "5.6.3",
-    "typescript-eslint_bottom": "npm:typescript-eslint@8.12.0"
+    "typescript-eslint_bottom": "npm:typescript-eslint@8.15.0"
   }
 }

--- a/src/plugin-usage/typescript-eslint.ts
+++ b/src/plugin-usage/typescript-eslint.ts
@@ -177,6 +177,7 @@ const usage: PluginUsage = {
     'no-unsafe-function-type': ['error'],
     'no-unsafe-member-access': ['error'],
     'no-unsafe-return': ['error'],
+    'no-unsafe-type-assertion': ['error'],
     'no-unsafe-unary-minus': ['error'],
     'no-unused-expressions': [
       'error',

--- a/src/test/_expected-exported-value.ts
+++ b/src/test/_expected-exported-value.ts
@@ -356,6 +356,7 @@ export const expectedTseslintRules: Record<
   '@typescript-eslint/no-unsafe-function-type': ['error'],
   '@typescript-eslint/no-unsafe-member-access': ['error'],
   '@typescript-eslint/no-unsafe-return': ['error'],
+  '@typescript-eslint/no-unsafe-type-assertion': ['error'],
   '@typescript-eslint/no-unsafe-unary-minus': ['error'],
   '@typescript-eslint/no-unused-expressions': [
     'error',

--- a/src/test/_rules_to_consider.ts
+++ b/src/test/_rules_to_consider.ts
@@ -186,7 +186,6 @@ export const rulesToConsider: Record<string, string[]> = {
     'promise/valid-params',
   ],
   '@typescript-eslint': [
-    '@typescript-eslint/no-unsafe-type-assertion',
     '@typescript-eslint/related-getter-setter-pairs',
     '@typescript-eslint/require-await',
     '@typescript-eslint/use-unknown-in-catch-callback-variable',

--- a/src/test/rules.ts
+++ b/src/test/rules.ts
@@ -48,6 +48,7 @@ const knownRules = new Map([
 
 const deprecatedKnownRules = [...knownRules.entries()]
   .filter(([_name, rule_]) => {
+    if (typeof rule_ !== 'object' || rule_ === null) throw new Error()
     const rule = rule_ as { meta?: { deprecated?: boolean } }
     const { meta } = rule
     if (meta === undefined) return false


### PR DESCRIPTION
BREAKING CHANGE: @typescript-eslint/no-unsafe-type-assertion and
bump minimum typescript-eslint to v8.15.0.
