### PR TITLE
feat: no-plusplus allowForLoopAfterthoughts=true

### DIFF
--- a/src/plugin-usage/eslint.ts
+++ b/src/plugin-usage/eslint.ts
@@ -113,7 +113,7 @@ const usage: PluginUsage = {
     'no-octal': ['error'],
     'no-octal-escape': ['error'],
     'no-param-reassign': ['error', { props: true }],
-    'no-plusplus': ['error'],
+    'no-plusplus': ['error', { allowForLoopAfterthoughts: true }],
     'no-proto': ['error'],
     'no-prototype-builtins': ['error'],
     'no-regex-spaces': ['error'],

--- a/src/test/expected-exported-value/_eslint.ts
+++ b/src/test/expected-exported-value/_eslint.ts
@@ -113,7 +113,7 @@ export const expectedEslintRules: Record<
   'no-octal': ['error'],
   'no-octal-escape': ['error'],
   'no-param-reassign': ['error', { props: true }],
-  'no-plusplus': ['error'],
+  'no-plusplus': ['error', { allowForLoopAfterthoughts: true }],
   'no-proto': ['error'],
   'no-prototype-builtins': ['error'],
   'no-regex-spaces': ['error'],


### PR DESCRIPTION
see docs: https://eslint.org/docs/latest/rules/no-plusplus

https://github.com/mightyiam/eslint-config-love/commit/69a9d17fb1d1a856ac47a349414049a49d02773c set `no-plusplus` to true. 
unfortunately, this causes errors for areas where plusplus are save: For-loop afterthoughts.

This PR fixes this - as a feature.