### PR TITLE
Remove stale eslint-plugin-import declarations

### DIFF
--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -18,16 +18,6 @@ declare module 'eslint-plugin-n_bottom' {
   const plugin: TSESLint.FlatConfig.Plugin
   export default plugin
 }
-declare module 'eslint-plugin-import' {
-  import type { TSESLint } from '@typescript-eslint/utils'
-  const plugin: TSESLint.FlatConfig.Plugin
-  export default plugin
-}
-declare module 'eslint-plugin-import_bottom' {
-  import type { TSESLint } from '@typescript-eslint/utils'
-  const plugin: TSESLint.FlatConfig.Plugin
-  export default plugin
-}
 declare module 'eslint-plugin-promise' {
   import type { TSESLint } from '@typescript-eslint/utils'
   const plugin: TSESLint.FlatConfig.Plugin


### PR DESCRIPTION
## Summary

Removes the ambient declarations for `eslint-plugin-import` and `eslint-plugin-import_bottom` that remained after #2441 removed those packages.

The declarations are no longer used and refer to packages that are no longer dependencies. This keeps the local type shims consistent with the current dependency graph.

There is no runtime or exported-config behavior change.

## Verification

- `npm ci`
- `npm test`
  - formatting
  - TypeScript compilation
  - 17 unit and integration tests
  - linting
  - compatibility with every minimum supported dependency version
